### PR TITLE
FS_RegistrationMail v2

### DIFF
--- a/Api/CreateContainer.ts
+++ b/Api/CreateContainer.ts
@@ -137,7 +137,7 @@ appContainer.declare("ProjectController", (c) => new ProjectController(c.Project
 appContainer.declare("GradeSheetController", (c) => new GradeSheetController(c.GradeSheetService));
 appContainer.declare("SectionController", (c) => new SectionController(c.SectionService));
 appContainer.declare("TeamController", (c) => new TeamController(c.TeamService));
-appContainer.declare("AuthController", (c) => new AuthController(c.AuthService));
+appContainer.declare("AuthController", (c) => new AuthController(c.AuthService, c.MailingService));
 appContainer.declare("GradeController", (c) => new GradeController(c.GradeService));
 
 


### PR DESCRIPTION
added the same welcome email to _api/register_

to test use: http://localhost:5000/api/register
body: 
{
 "name": "test",
 "email": "yourmail",
 "surname": "test",
 "password": "elo420hahAh-hsas",
 "confirmPassword": "elo420hahAh-hsas"
}
