### PR TITLE
KR new header for components

### DIFF
--- a/frontend/src/components/Header/Header.module.css
+++ b/frontend/src/components/Header/Header.module.css
@@ -18,7 +18,7 @@
 }
 
 .logo span{
-  color: #1A90FF;
+  color: #ffc53d;
 }
 
 .logout{

--- a/frontend/src/components/HeaderRegistration/HeaderRegistration.module.css
+++ b/frontend/src/components/HeaderRegistration/HeaderRegistration.module.css
@@ -1,0 +1,26 @@
+@import url('https://fonts.googleapis.com/css2?family=Sarpanch:wght@600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@500&family=Sarpanch:wght@600&display=swap');
+
+.header {
+  width: 100%;
+  padding: 10px 0;
+  background-color: #292929;
+  color: #FFFFFF;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #666666;
+}
+
+.logo{
+    margin-left: 2rem;
+    font-family:'Sarpanch', sans-serif;
+    font-size: 2rem;
+}
+
+.logo span{
+  color: #ffc53d;
+}
+
+
+

--- a/frontend/src/components/HeaderRegistration/HeaderRegistration.stories.tsx
+++ b/frontend/src/components/HeaderRegistration/HeaderRegistration.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import HeaderRegistration from './HeaderRegistration';
+
+export default {
+  title: 'HeaderRegistration component',
+  component: HeaderRegistration,
+} as Meta;
+
+const Template: Story = (args) => <HeaderRegistration {...args} />;
+
+export const BasicHeaderRegistration = Template.bind({});

--- a/frontend/src/components/HeaderRegistration/HeaderRegistration.test.tsx
+++ b/frontend/src/components/HeaderRegistration/HeaderRegistration.test.tsx
@@ -6,5 +6,6 @@ describe("HeaderRegistration", () => {
   it("should render header registration", () => {
    const {container}= render(<HeaderRegistration />);
     expect(container).toMatchSnapshot()
+    
   });
 });

--- a/frontend/src/components/HeaderRegistration/HeaderRegistration.test.tsx
+++ b/frontend/src/components/HeaderRegistration/HeaderRegistration.test.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import HeaderRegistration from "./index";
+import { render} from "@testing-library/react";
+
+describe("HeaderRegistration", () => {
+  it("should render header registration", () => {
+   const {container}= render(<HeaderRegistration />);
+    expect(container).toMatchSnapshot()
+  });
+});

--- a/frontend/src/components/HeaderRegistration/HeaderRegistration.tsx
+++ b/frontend/src/components/HeaderRegistration/HeaderRegistration.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styles from './HeaderRegistration.module.css'
+import PowerSettingsNewIcon from '@material-ui/icons/PowerSettingsNew';
+
+const HeaderRegistration: React.FC= () => {
+  return (
+    <div className={styles.header}>
+        <div className={styles.logo}><span>.</span>Coders<span>Camp</span></div>
+        <div></div>
+    </div>
+   );
+};
+
+export default HeaderRegistration;

--- a/frontend/src/components/HeaderRegistration/HeaderRegistration.tsx
+++ b/frontend/src/components/HeaderRegistration/HeaderRegistration.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import styles from './HeaderRegistration.module.css'
-import PowerSettingsNewIcon from '@material-ui/icons/PowerSettingsNew';
 
 const HeaderRegistration: React.FC= () => {
   return (
     <div className={styles.header}>
         <div className={styles.logo}><span>.</span>Coders<span>Camp</span></div>
-        <div></div>
     </div>
    );
 };

--- a/frontend/src/components/HeaderRegistration/__snapshots__/HeaderRegistration.test.tsx.snap
+++ b/frontend/src/components/HeaderRegistration/__snapshots__/HeaderRegistration.test.tsx.snap
@@ -1,43 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HeaderRegistration should render header 1`] = `
-<div>
-  <div
-    class="header"
-  >
-    <div
-      class="logo"
-    >
-      <span>
-        .
-      </span>
-      Coders
-      <span>
-        Camp
-      </span>
-    </div>
-    <div
-      class="logout"
-    >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root"
-        focusable="false"
-        style="color: rgba(255, 255, 255, 0.6);"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M13 3h-2v10h2V3zm4.83 2.17l-1.42 1.42C17.99 7.86 19 9.81 19 12c0 3.87-3.13 7-7 7s-7-3.13-7-7c0-2.19 1.01-4.14 2.58-5.42L6.17 5.17C4.23 6.82 3 9.26 3 12c0 4.97 4.03 9 9 9s9-4.03 9-9c0-2.74-1.23-5.18-3.17-6.83z"
-        />
-      </svg>
-      <span>
-         Log out
-      </span>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`HeaderRegistration should render header registration 1`] = `
 <div>
   <div
@@ -54,7 +16,6 @@ exports[`HeaderRegistration should render header registration 1`] = `
         Camp
       </span>
     </div>
-    <div />
   </div>
 </div>
 `;

--- a/frontend/src/components/HeaderRegistration/__snapshots__/HeaderRegistration.test.tsx.snap
+++ b/frontend/src/components/HeaderRegistration/__snapshots__/HeaderRegistration.test.tsx.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HeaderRegistration should render header 1`] = `
+<div>
+  <div
+    class="header"
+  >
+    <div
+      class="logo"
+    >
+      <span>
+        .
+      </span>
+      Coders
+      <span>
+        Camp
+      </span>
+    </div>
+    <div
+      class="logout"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root"
+        focusable="false"
+        style="color: rgba(255, 255, 255, 0.6);"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M13 3h-2v10h2V3zm4.83 2.17l-1.42 1.42C17.99 7.86 19 9.81 19 12c0 3.87-3.13 7-7 7s-7-3.13-7-7c0-2.19 1.01-4.14 2.58-5.42L6.17 5.17C4.23 6.82 3 9.26 3 12c0 4.97 4.03 9 9 9s9-4.03 9-9c0-2.74-1.23-5.18-3.17-6.83z"
+        />
+      </svg>
+      <span>
+         Log out
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`HeaderRegistration should render header registration 1`] = `
+<div>
+  <div
+    class="header"
+  >
+    <div
+      class="logo"
+    >
+      <span>
+        .
+      </span>
+      Coders
+      <span>
+        Camp
+      </span>
+    </div>
+    <div />
+  </div>
+</div>
+`;

--- a/frontend/src/components/HeaderRegistration/index.ts
+++ b/frontend/src/components/HeaderRegistration/index.ts
@@ -1,0 +1,1 @@
+export { default } from './HeaderRegistration';

--- a/frontend/src/components/LogIn/LogIn.tsx
+++ b/frontend/src/components/LogIn/LogIn.tsx
@@ -17,6 +17,7 @@ import MuiAlert, { AlertProps }  from '@material-ui/lab/Alert';
 import StyledTextField from '../StyledTextField'
 import useStyles from './LogIn.style';
 import BaseService from '../../app/baseService';
+import HeaderRegistration from '../HeaderRegistration';
 
 export interface LogInProps {
 
@@ -73,6 +74,8 @@ export default function SignIn() {
   };
 
   return (
+    <div>
+      <HeaderRegistration />
     <Container component="main" maxWidth="xs">
       <CssBaseline />
       <div className={classes.paper}>
@@ -131,5 +134,6 @@ export default function SignIn() {
         </form>
       </div>
     </Container>
+    </div>
   );
 }

--- a/frontend/src/components/Registration/Registration.tsx
+++ b/frontend/src/components/Registration/Registration.tsx
@@ -14,6 +14,7 @@ import MuiAlert, { AlertProps }  from '@material-ui/lab/Alert';
 import StyledTextField from '../StyledTextField';
 import BaseService from '../../app/baseService';
 import useStyles from './Registration.style';
+import HeaderRegistration from '../HeaderRegistration';
 
 export interface RegistrationProps {
   
@@ -59,6 +60,8 @@ export default function SignUp() {
   const areAllFieldsFilled = name && surname && email && password && confirmPassword;
 
   return (
+    <div>
+      <HeaderRegistration />
     <Container component="main" maxWidth="xs">
       <CssBaseline />
       <div className={classes.paper}>
@@ -155,5 +158,6 @@ export default function SignUp() {
         </form>
       </div>
     </Container>
+    </div>
   );
 }

--- a/frontend/src/components/ResetPassword/ResetPassword.tsx
+++ b/frontend/src/components/ResetPassword/ResetPassword.tsx
@@ -9,6 +9,7 @@ import {
 import { makeStyles } from '@material-ui/core/styles';
 
 import StyledTextField from '../StyledTextField'
+import HeaderRegistration from '../HeaderRegistration';
 
 export interface ResetPasswordProps {
 
@@ -36,6 +37,8 @@ export default function ResetPassword() {
   const classes = useStyles();
 
   return (
+<div>
+<HeaderRegistration />
     <Container component="main" maxWidth="xs">
       <CssBaseline />
       <div className={classes.paper}>
@@ -66,5 +69,6 @@ export default function ResetPassword() {
         </form>
       </div>
     </Container>
+    </div>
   );
 }


### PR DESCRIPTION
I made a new header for login, registration and reset password and I added it to these components. 
I also changed the color of the logo to orange. 

After Filip completes the task with routes, the double header in /login, /registration and /resetpassword will disappear.